### PR TITLE
Upgrade python-dateutil 

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ hjson
 jmespath
 kappa==0.6.0
 pip>=9.0.1
-python-dateutil<2.7.0
+python-dateutil
 python-slugify
 PyYAML
 future

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ jmespath==0.9.4
 kappa==0.6.0
 pip-tools==4.5.0
 placebo==0.9.0            # via kappa
-python-dateutil==2.6.1
+python-dateutil==2.8.1
 python-slugify==4.0.0
 pyyaml==5.3
 requests==2.23.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -38,7 +38,7 @@ pip-tools==4.5.0
 placebo==0.9.0
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
-python-dateutil==2.6.1
+python-dateutil==2.8.1
 python-slugify==4.0.0
 pytz==2019.3              # via django
 pyyaml==5.3

--- a/zappa/__init__.py
+++ b/zappa/__init__.py
@@ -8,4 +8,4 @@ if sys.version_info[:2] not in SUPPORTED_VERSIONS:
                'Zappa (and AWS Lambda) support the following versions of Python: {}'.format(formatted_supported_versions))
     raise RuntimeError(err_msg)
 
-__version__ = '0.51.8'
+__version__ = '0.51.9'


### PR DESCRIPTION
python-dateutil 버전이 너무 오래되서 다른 패키지 설치에 영향을 줍니다.
최신 버전으로 업데이트했고, 내부 테스트 스크립트 돌렸을 때 이상 없음을 확인했습니다.

